### PR TITLE
Bugfix: Single Image Container Post Failure

### DIFF
--- a/bot/pkg/poster/poster.go
+++ b/bot/pkg/poster/poster.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"image"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -32,15 +33,9 @@ func New(accessToken, userID, imgurClientID string) *Poster {
 // Post posts the images to Threads
 func (p *Poster) Post(images []image.Image, title string, publishTime time.Time, documentURL string) error {
 	// Upload images to Imgur
-	var imageURLs []string
-	for i, img := range images {
-		imgTitle := fmt.Sprintf("%s - Page %d", title, i+1)
-		imgDescription := fmt.Sprintf("Page %d of document: %s", i+1, title)
-		url, err := p.ImgurClient.UploadImage(img, imgTitle, imgDescription)
-		if err != nil {
-			return fmt.Errorf("failed to upload image %d to Imgur: %v", i+1, err)
-		}
-		imageURLs = append(imageURLs, url)
+	imageURLs, err := p.uploadImages(images, title)
+	if err != nil {
+		return err
 	}
 
 	// Format the text for the post
@@ -49,19 +44,34 @@ func (p *Poster) Post(images []image.Image, title string, publishTime time.Time,
 	// Determine whether to post a single image or a carousel based on the number of images
 	if len(imageURLs) == 1 {
 		// Single image post
-		log.Println("single image returned")
 		return p.postSingleImage(imageURLs[0], postText)
 	} else if len(imageURLs) >= 2 && len(imageURLs) <= 20 {
 		// Carousel post
-		log.Println("multiple images retutned")
 		return p.postCarousel(imageURLs, postText)
-	} else {
-		return fmt.Errorf("invalid number of images: %d. Must be between 1 and 20", len(imageURLs))
 	}
+
+	return fmt.Errorf("invalid number of images: %d. Must be between 1 and 20", len(imageURLs))
+}
+
+// uploadImages uploads the given images to Imgur and returns their URLs
+func (p *Poster) uploadImages(images []image.Image, title string) ([]string, error) {
+	var imageURLs []string
+	for i, img := range images {
+		imgTitle := fmt.Sprintf("%s - Page %d", title, i+1)
+		imgDescription := fmt.Sprintf("Page %d of document: %s", i+1, title)
+		url, err := p.ImgurClient.UploadImage(img, imgTitle, imgDescription)
+		if err != nil {
+			return nil, fmt.Errorf("failed to upload image %d to Imgur: %v", i+1, err)
+		}
+		imageURLs = append(imageURLs, url)
+	}
+	return imageURLs, nil
 }
 
 // postSingleImage posts a single image to Threads
 func (p *Poster) postSingleImage(imageURL, postText string) error {
+	log.Printf("Posting single image: %s", imageURL)
+
 	// Create item container for the single image
 	itemID, err := p.createItemContainer(imageURL, false)
 	if err != nil {
@@ -69,25 +79,23 @@ func (p *Poster) postSingleImage(imageURL, postText string) error {
 	}
 
 	// Create media container with the image and text
-	mediaID, err := p.createMediaContainer(itemID, postText, "IMAGE")
+	mediaID, err := p.createMediaContainer(itemID, postText, "IMAGE", imageURL)
 	if err != nil {
 		return fmt.Errorf("failed to create media container: %v", err)
 	}
 
 	// Wait for 30 seconds as recommended by the API documentation
+	log.Println("Waiting 30 seconds before publishing...")
 	time.Sleep(30 * time.Second)
 
 	// Publish the media
-	err = p.publishMedia(mediaID)
-	if err != nil {
-		return fmt.Errorf("failed to publish media: %v", err)
-	}
-
-	return nil
+	return p.publishMedia(mediaID)
 }
 
 // postCarousel posts a carousel of images to Threads
 func (p *Poster) postCarousel(imageURLs []string, postText string) error {
+	log.Printf("Posting carousel with %d images", len(imageURLs))
+
 	// Create item containers for each image
 	var itemIDs []string
 	for _, url := range imageURLs {
@@ -105,15 +113,11 @@ func (p *Poster) postCarousel(imageURLs []string, postText string) error {
 	}
 
 	// Wait for 30 seconds as recommended by the API documentation
+	log.Println("Waiting 30 seconds before publishing...")
 	time.Sleep(30 * time.Second)
 
 	// Publish the carousel
-	err = p.publishCarousel(carouselID)
-	if err != nil {
-		return fmt.Errorf("failed to publish carousel: %v", err)
-	}
-
-	return nil
+	return p.publishCarousel(carouselID)
 }
 
 // formatPostText formats the text for the post
@@ -127,9 +131,7 @@ func formatPostText(title string, publishTime time.Time, documentURL string) str
 	escapedURL := url.QueryEscape(documentURL)
 
 	return fmt.Sprintf("New document: %s\nPublished on: %s\n\nLink to document: %s\n\n#F1Threads",
-		title,
-		publishTime.Format("02-01-2006 15:04 MST"),
-		escapedURL)
+		title, publishTime.Format("02-01-2006 15:04 MST"), escapedURL)
 }
 
 // createItemContainer creates an item container for the image
@@ -137,44 +139,16 @@ func (p *Poster) createItemContainer(imageURL string, isCarouselItem bool) (stri
 	url := fmt.Sprintf("https://graph.threads.net/v1.0/%s/threads", p.UserID)
 	payload := fmt.Sprintf("media_type=IMAGE&image_url=%s&is_carousel_item=%t&access_token=%s", imageURL, isCarouselItem, p.AccessToken)
 
-	resp, err := http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	var result struct {
-		ID string `json:"id"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	if err != nil {
-		return "", err
-	}
-
-	return result.ID, nil
+	return p.makePostRequest(url, payload)
 }
 
 // createMediaContainer creates a media container for a single image post
-func (p *Poster) createMediaContainer(itemID, text, mediaType string) (string, error) {
+func (p *Poster) createMediaContainer(itemID, text, mediaType, imageURL string) (string, error) {
 	url := fmt.Sprintf("https://graph.threads.net/v1.0/%s/threads", p.UserID)
-	payload := fmt.Sprintf("media_type=%s&text=%s&children=%s&access_token=%s",
-		mediaType, text, itemID, p.AccessToken)
+	payload := fmt.Sprintf("media_type=%s&text=%s&children=%s&image_url=%s&access_token=%s",
+		mediaType, text, itemID, imageURL, p.AccessToken)
 
-	resp, err := http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	var result struct {
-		ID string `json:"id"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	if err != nil {
-		return "", err
-	}
-
-	return result.ID, nil
+	return p.makePostRequest(url, payload)
 }
 
 // createCarouselContainer creates a carousel container for the images
@@ -183,21 +157,7 @@ func (p *Poster) createCarouselContainer(itemIDs []string, text string) (string,
 	payload := fmt.Sprintf("media_type=CAROUSEL&children=%s&text=%s&access_token=%s",
 		strings.Join(itemIDs, ","), text, p.AccessToken)
 
-	resp, err := http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	var result struct {
-		ID string `json:"id"`
-	}
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	if err != nil {
-		return "", err
-	}
-
-	return result.ID, nil
+	return p.makePostRequest(url, payload)
 }
 
 // publishMedia publishes a single image post to Threads
@@ -205,17 +165,8 @@ func (p *Poster) publishMedia(mediaID string) error {
 	url := fmt.Sprintf("https://graph.threads.net/v1.0/%s/threads_publish", p.UserID)
 	payload := fmt.Sprintf("creation_id=%s&access_token=%s", mediaID, p.AccessToken)
 
-	resp, err := http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to publish single media post: %s", resp.Status)
-	}
-
-	return nil
+	_, err := p.makePostRequest(url, payload)
+	return err
 }
 
 // publishCarousel publishes the carousel to Threads
@@ -223,15 +174,33 @@ func (p *Poster) publishCarousel(carouselID string) error {
 	url := fmt.Sprintf("https://graph.threads.net/v1.0/%s/threads_publish", p.UserID)
 	payload := fmt.Sprintf("creation_id=%s&access_token=%s", carouselID, p.AccessToken)
 
+	_, err := p.makePostRequest(url, payload)
+	return err
+}
+
+// makePostRequest is a helper function to make POST requests to the Threads API
+func (p *Poster) makePostRequest(url, payload string) (string, error) {
 	resp, err := http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("failed to publish carousel media post: %v", err)
+		return "", err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to publish carousel media post: %s", resp.Status)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
 	}
 
-	return nil
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+
+	return result.ID, nil
 }


### PR DESCRIPTION
# Fix Single Image Posting Issue

## Bug
Bot failed to post when there was only one image, attempting to create a carousel instead of a single image post. Resulting in `500 Internal Server Error` via Threads API

## Fix
- Updated `Post` function to handle single image case
- Added `postSingleImage` function for single image posts
- Fixed `createMediaContainer` to include required `image_url` parameter

## Testing
Tested via updated docker container in my prod setup; it resolved this error