### PR TITLE
Fix memory leak by optimizing scraper and garbage collection

### DIFF
--- a/bot/cmd/svc/main.go
+++ b/bot/cmd/svc/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -163,6 +164,12 @@ func processDocument(doc *scraper.Document, scraper *scraper.Scraper, summarizer
 
 	log.Printf("Successfully posted to Threads: %s", doc.Title)
 
+	// Add explicit cleanup after using images
+	for i := range images {
+		images[i] = nil // Help GC by explicitly nulling references
+	}
+	images = nil
+
 	// Update storage after successful posting
 	err = store.AddProcessedDocument(storage.ProcessedDocument{
 		Title:     doc.Title,
@@ -172,4 +179,7 @@ func processDocument(doc *scraper.Document, scraper *scraper.Scraper, summarizer
 	if err != nil {
 		log.Printf("Error updating storage: %v", err)
 	}
+
+	// Force garbage collection after processing large documents
+	runtime.GC()
 }

--- a/bot/pkg/scraper/scraper.go
+++ b/bot/pkg/scraper/scraper.go
@@ -19,17 +19,12 @@ type Document struct {
 }
 
 type Scraper struct {
-	baseURL   string
-	collector *colly.Collector
+	baseURL string
 }
 
 func New(baseURL string) *Scraper {
-	c := colly.NewCollector()
-	c.AllowURLRevisit = true // Allow revisiting the same URL
-
 	return &Scraper{
-		baseURL:   baseURL,
-		collector: c,
+		baseURL: baseURL,
 	}
 }
 
@@ -37,7 +32,11 @@ func New(baseURL string) *Scraper {
 func (s *Scraper) FetchLatestDocuments(limit int) ([]*Document, error) {
 	var documents []*Document
 
-	s.collector.OnHTML("ul.event-wrapper", func(e *colly.HTMLElement) {
+	// Create a fresh collector for each request
+	c := colly.NewCollector()
+	c.AllowURLRevisit = true
+
+	c.OnHTML("ul.event-wrapper", func(e *colly.HTMLElement) {
 		// Find the active (current) Grand Prix
 		e.ForEach("li", func(_ int, el *colly.HTMLElement) {
 			if el.ChildText(".event-title.active") != "" {
@@ -69,7 +68,7 @@ func (s *Scraper) FetchLatestDocuments(limit int) ([]*Document, error) {
 		})
 	})
 
-	err := s.collector.Visit(s.baseURL)
+	err := c.Visit(s.baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("error visiting %s: %v", s.baseURL, err)
 	}


### PR DESCRIPTION
- Created new collector instances for each scraping operation instead of reusing a single instance
- Added explicit cleanup for image objects after PDF processing
- Forced garbage collection after processing documents
- Modified scraper implementation to avoid state accumulation between requests