### PR TITLE
Fix handling of recalled FIA documents

### DIFF
--- a/bot/go.mod
+++ b/bot/go.mod
@@ -1,7 +1,8 @@
 module bot
 
-go 1.23
-toolchain go1.23.1
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/spf13/viper v1.19.0

--- a/bot/pkg/poster/poster.go
+++ b/bot/pkg/poster/poster.go
@@ -85,7 +85,7 @@ func (p *Poster) PostTextOnly(text string) error {
 	encodedText := strings.ReplaceAll(url.QueryEscape(text), "+", "%20")
 
 	// Create the payload for a text-only post
-	payload := fmt.Sprintf("text=%s&access_token=%s", encodedText, p.AccessToken)
+	payload := fmt.Sprintf("media_type=TEXT&text=%s&access_token=%s", encodedText, p.AccessToken)
 
 	// Make the API request to create the text-only post
 	mediaID, err := p.makePostRequest(threadsURL, payload)
@@ -102,18 +102,6 @@ func (p *Poster) PostTextOnly(text string) error {
 
 	log.Printf("Successfully posted text-only message")
 	return nil
-}
-
-// formatJSONString properly escapes a string for JSON
-func formatJSONString(s string) string {
-	bytes, err := json.Marshal(s)
-	if err != nil {
-		// If marshaling fails, do a basic escaping
-		s = strings.ReplaceAll(s, "\"", "\\\"")
-		s = strings.ReplaceAll(s, "\n", "\\n")
-		return fmt.Sprintf("\"%s\"", s)
-	}
-	return string(bytes)
 }
 
 // uploadImages uploads the given images to Picsur and returns their URLs


### PR DESCRIPTION
When the FIA recalls a document, it still appears in their document list but has no valid PDF content. This was causing errors in our processing pipeline.

This PR:

- Adds detection for recalled documents (by title and PDF validation)
- Implements text-only posting capability for recalled documents
- Updates the main flow to post informative messages about recalled documents

Now when a document is recalled, the bot posts a text-only message informing followers rather than failing silently.