### PR TITLE
Refactor request ID handling in logger package for consistency

### DIFF
--- a/bot/pkg/logger/logger.go
+++ b/bot/pkg/logger/logger.go
@@ -20,7 +20,7 @@ const (
 	LevelError Level = "error"
 
 	// Context key for request ID
-	ctxKeyRequestID = "request_id"
+	ctxKeyRequestID = "requestID"
 )
 
 // Logger wraps slog.Logger for structured logging
@@ -201,7 +201,7 @@ func (l *Logger) WithRequestContext(ctx context.Context) *Logger {
 		reqID = "unknown"
 	}
 
-	logger := l.Logger.With("request_id", reqID)
+	logger := l.Logger.With("requestID", reqID)
 	return &Logger{
 		Logger:      logger,
 		serviceName: l.serviceName,

--- a/bot/pkg/logger/logger.go
+++ b/bot/pkg/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -228,11 +227,6 @@ func NewRequestContext() (context.Context, string) {
 
 // Helper to generate a unique request ID
 func generateRequestID() string {
-	hostname := os.Getenv("HOSTNAME")
-	if hostname == "" {
-		hostname = "local"
-	}
-
 	id := uuid.New()
-	return fmt.Sprintf("%s-%s", hostname, id.String())
+	return id.String()
 }


### PR DESCRIPTION
This MR improves the request ID handling in the logger package with two key changes:

1. Simplified the request ID generation by:
   - Removing hostname prefix from the request ID
   - Using only UUID for cleaner and more consistent IDs

2. Updated request ID key naming for consistency:
   - Changed context key from "request_id" to "requestID"
   - Updated logger context to use the new key in WithRequestContext method
