### PR TITLE
fix: Update text-only processing logic to handle posting failures

### DIFF
--- a/bot/cmd/svc/main.go
+++ b/bot/cmd/svc/main.go
@@ -207,9 +207,11 @@ func main() {
 				err := postRecalledDocumentNotice(cycleCtx, poster, doc)
 				if err != nil {
 					cycleLog.Error("Error posting recalled document notice", "error", err)
+					// Skip marking as processed if posting the notice failed, allow retry next cycle
+					continue
 				}
 
-				// Mark as processed to avoid repeated attempts
+				// Mark as processed only if the notice was successfully posted
 				cycleLog.Info("Marking recalled document as processed")
 				err = store.AddProcessedDocument(cycleCtx, storage.ProcessedDocument{
 					Title:     doc.Title,

--- a/bot/pkg/poster/poster.go
+++ b/bot/pkg/poster/poster.go
@@ -124,6 +124,9 @@ func (p *Poster) PostTextOnly(ctx context.Context, text string) error {
 
 	ctxLog.Debug("Created text-only post", "mediaID", mediaID)
 
+	ctxLog.Info("Waiting before publishing text-only post...")
+	time.Sleep(2 * time.Second)
+
 	// Publish the post
 	if err := p.publishMedia(ctx, mediaID); err != nil {
 		ctxLog.Error("Failed to publish text-only post", "error", err)


### PR DESCRIPTION
- Modified the logic to skip marking documents as processed if posting the recall notice fails, allowing for retries in the next cycle.
- Added a delay before publishing text-only posts to improve reliability.