### PR TITLE
Cleanup go lint & change image format

### DIFF
--- a/bot/pkg/logger/logger.go
+++ b/bot/pkg/logger/logger.go
@@ -145,11 +145,6 @@ func SetDefaultLogger(logger *Logger) {
 	defaultLogger = logger
 }
 
-// GetDefaultLogger returns the default logger
-func GetDefaultLogger() *Logger {
-	return defaultLogger
-}
-
 // Package returns a logger for a specific package
 func Package(pkg string) *Logger {
 	if defaultLogger == nil {

--- a/bot/pkg/storage/postgres.go
+++ b/bot/pkg/storage/postgres.go
@@ -90,7 +90,10 @@ func NewPostgres(host, port, user, password, dbname, sslmode string) (StorageInt
 			`)
 
 			if err != nil {
-				tx.Rollback()
+				err := tx.Rollback()
+				if err != nil {
+					return nil, fmt.Errorf("error rolling back transaction: %v", err)
+				}
 				ctxLog.Error("Error dropping constraint", "error", err)
 				return nil, fmt.Errorf("error dropping constraint: %v", err)
 			}
@@ -101,7 +104,10 @@ func NewPostgres(host, port, user, password, dbname, sslmode string) (StorageInt
 			`)
 
 			if err != nil {
-				tx.Rollback()
+				err := tx.Rollback()
+				if err != nil {
+					return nil, fmt.Errorf("error rolling back transaction: %v", err)
+				}
 				ctxLog.Error("Error adding new constraint", "error", err)
 				return nil, fmt.Errorf("error adding new constraint: %v", err)
 			}

--- a/bot/pkg/summary/summary.go
+++ b/bot/pkg/summary/summary.go
@@ -54,7 +54,10 @@ func (s *Summarizer) Close() {
 
 	if s.client != nil {
 		ctxLog.Info("Closing Gemini client")
-		s.client.Close()
+		err := s.client.Close()
+		if err != nil {
+			fmt.Printf("Error closing Gemini client: %v", err)
+		}
 	}
 }
 
@@ -144,7 +147,12 @@ func (s *Summarizer) uploadFile(ctx context.Context, path, mimeType string) (str
 		ctxLog.Error("Error opening file", "error", err)
 		return "", fmt.Errorf("error opening file: %w", err)
 	}
-	defer file.Close()
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			ctxLog.Error("Error closing file", "error", err)
+		}
+	}(file)
 
 	options := genai.UploadFileOptions{
 		DisplayName: path,

--- a/bot/pkg/utils/shortener.go
+++ b/bot/pkg/utils/shortener.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 )
 
@@ -76,7 +77,12 @@ func (c *ShortenerClient) ShortenURL(ctx context.Context, longURL string) (strin
 		ctxLog.Error("Failed to send request", "error", err)
 		return "", fmt.Errorf("failed to send request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			ctxLog.Error("Failed to close response body", "error", err)
+		}
+	}(resp.Body)
 
 	// Check response status - accept both 200 OK and 201 Created as success
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {

--- a/bot/pkg/utils/utils.go
+++ b/bot/pkg/utils/utils.go
@@ -49,7 +49,7 @@ func New(apiKey, baseURL string) *Client {
 	}
 }
 
-func (c *Client) UploadImage(ctx context.Context, img image.Image, title, description string) (string, error) {
+func (c *Client) UploadImage(ctx context.Context, img image.Image) (string, error) {
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "UploadImage")
 
@@ -107,7 +107,12 @@ func (c *Client) UploadImage(ctx context.Context, img image.Image, title, descri
 		ctxLog.Error("Failed to send request", "error", err)
 		return "", fmt.Errorf("failed to send request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			ctxLog.Error("Failed to close response body", "error", err)
+		}
+	}(resp.Body)
 
 	// Parse response
 	var picsurResp picsurResponse
@@ -122,17 +127,17 @@ func (c *Client) UploadImage(ctx context.Context, img image.Image, title, descri
 	}
 
 	// Construct the image URL from the response ID
-	imageURL := fmt.Sprintf("%s/i/%s.png", c.BaseURL, picsurResp.Data.ID)
+	imageURL := fmt.Sprintf("%s/i/%s.jpg", c.BaseURL, picsurResp.Data.ID)
 	ctxLog.Debug("Image uploaded successfully", "url", imageURL)
 	return imageURL, nil
 }
 
-// Custom function to encode spaces in URL
+// EncodeURL encodes spaces in URL
 func EncodeURL(input string) string {
 	return strings.ReplaceAll(input, " ", "%20")
 }
 
-// Refresh the long-lived access token for the Threads API
+// RefreshToken refreshes the long-lived access token for the Threads API
 func RefreshToken(ctx context.Context, refreshToken string) (string, error) {
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "RefreshToken")
@@ -159,7 +164,12 @@ func RefreshToken(ctx context.Context, refreshToken string) (string, error) {
 		ctxLog.Error("Failed to send request", "error", err)
 		return "", fmt.Errorf("failed to send request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			ctxLog.Error("Failed to close response body", "error", err)
+		}
+	}(resp.Body)
 
 	// Parse response
 	var tokenResp struct {
@@ -189,7 +199,12 @@ func ConvertToImages(ctx context.Context, pdfPath string) ([]image.Image, error)
 		ctxLog.Error("Failed to open PDF", "error", err)
 		return nil, fmt.Errorf("failed to open PDF: %v", err)
 	}
-	defer doc.Close()
+	defer func(doc *fitz.Document) {
+		err := doc.Close()
+		if err != nil {
+			ctxLog.Error("Failed to close document", "error", err)
+		}
+	}(doc)
 
 	numPages := doc.NumPage()
 	ctxLog.Debug("Converting PDF to images", "pages", numPages)


### PR DESCRIPTION
Cleaned up go lint suggestions and changed the image url format received from Picsur to use JPG. Threads has 8MB image size limit which was being broken by few cases where images were too large