### PR TITLE
feat: add govulncheck CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 12 * * *' # daily at noon UTC
 
+permissions:
+  contents: read
+
 jobs:
   govulncheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 12 * * *' # daily at noon UTC
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: bot/go.mod
+
+      - name: Run govulncheck
+        working-directory: bot
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
         with:
           go-version-file: bot/go.mod
-
-      - name: Run govulncheck
-        working-directory: bot
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+          go-package: ./...
+          work-dir: bot


### PR DESCRIPTION
## Summary
- Adds a CI workflow running `govulncheck` on PRs, pushes to main, and daily via cron
- Replaces the need for Dependabot by only flagging reachable vulnerabilities (see [filippo.io/dependabot](https://words.filippo.io/dependabot/))

## Test plan
- [ ] Verify workflow runs successfully on this PR