### PR TITLE
fix: chain >20-image posts as image-only replies

### DIFF
--- a/bot/go.mod
+++ b/bot/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/lib/pq v1.12.0
 	github.com/spf13/viper v1.21.0
 	github.com/tirthpatell/threads-go v1.7.1
+	golang.org/x/sync v0.20.0
 )
 
 require (

--- a/bot/pkg/poster/poster.go
+++ b/bot/pkg/poster/poster.go
@@ -237,7 +237,7 @@ func (p *Poster) postSingleImage(ctx context.Context, imageURL, postText, replyT
 		Text:     postText,
 		ImageURL: imageURL,
 		ReplyTo:  replyToID,
-		TopicTag: TopicTag,
+		TopicTag: topicTagForReply(replyToID),
 	})
 	if err != nil {
 		ctxLog.Error("Failed to create image post", "error", err)
@@ -272,7 +272,7 @@ func (p *Poster) postCarousel(ctx context.Context, imageURLs []string, postText,
 		Text:     postText,
 		Children: containerIDs,
 		ReplyTo:  replyToID,
-		TopicTag: TopicTag,
+		TopicTag: topicTagForReply(replyToID),
 	})
 	if err != nil {
 		ctxLog.Error("Failed to create carousel post", "error", err)
@@ -359,10 +359,21 @@ func truncateText(text string, limit int) string {
 	return text[:lastSpace] + ellipsis
 }
 
+// topicTagForReply returns the topic tag to apply to a post: TopicTag for the
+// root post (empty replyToID), and "" for replies — the Threads API only
+// allows topic tags on root posts, not on replies.
+func topicTagForReply(replyToID string) string {
+	if replyToID == "" {
+		return TopicTag
+	}
+	return ""
+}
+
 // chunkURLs partitions urls into consecutive slices of length ≤ size.
-// Returns nil for an empty input. The last chunk may be shorter than size.
+// Returns nil for an empty input or non-positive size. The last chunk may be
+// shorter than size.
 func chunkURLs(urls []string, size int) [][]string {
-	if len(urls) == 0 {
+	if len(urls) == 0 || size <= 0 {
 		return nil
 	}
 	chunks := make([][]string, 0, (len(urls)+size-1)/size)

--- a/bot/pkg/poster/poster.go
+++ b/bot/pkg/poster/poster.go
@@ -18,6 +18,7 @@ var log = logger.Package("poster")
 
 const (
 	maxCharacterLimit = 500
+	maxImagesPerPost  = 20
 	ellipsis          = "..."
 	TopicTag          = "F1Threads"
 )
@@ -55,16 +56,26 @@ func New(accessToken, userID, clientID, clientSecret, redirectURI, picsurAPI, pi
 	}, nil
 }
 
-// Post posts the images to Threads
+// Post posts the images to Threads. When more than maxImagesPerPost images are
+// provided, the post is split into a chain: the first chunk becomes the root
+// post (with the AI summary text); each subsequent chunk is posted as an
+// image-only reply to the previous post in the chain.
+//
+// Failure policy:
+//   - Root post failure: returns the error; caller skips marking the document
+//     as processed and will retry on the next scrape cycle.
+//   - Reply chunk failure: logs the failure with the root post ID and chunk
+//     index, then returns nil. The root post and any earlier replies remain
+//     published; the document is marked processed so we don't re-publish the
+//     root on the next cycle. Some tail images may be lost.
 func (p *Poster) Post(ctx context.Context, images []image.Image, title string, publishTime time.Time, documentURL, aiSummary string) error {
 	start := time.Now()
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "Post")
 
-	// Limit to 20 images if there are more
-	if len(images) > 20 {
-		ctxLog.Warn("Limiting images due to Threads API limitations", "original", len(images), "limited", 20)
-		images = images[:20]
+	if len(images) == 0 {
+		ctxLog.Warn("Post called with zero images; nothing to do")
+		return nil
 	}
 
 	// Upload images to Picsur
@@ -83,45 +94,63 @@ func (p *Poster) Post(ctx context.Context, images []image.Image, title string, p
 		"count", len(imageURLs),
 		"upload_duration_ms", uploadDuration.Milliseconds())
 
-	// Format the text for the post
+	// Format the text for the root post
 	ctxLog.Debug("Formatting post text")
 	postText, err := p.formatPostText(ctx, title, publishTime, documentURL, aiSummary)
 	if err != nil {
 		ctxLog.ErrorWithType("Failed to format post text", err)
 		return err
 	}
-
 	ctxLog.Debug("Post character count", "chars", len(postText))
 
-	// Determine whether to post a single image or a carousel based on the number of images
-	var postErr error
+	// Partition images into chunks of ≤ maxImagesPerPost
+	chunks := chunkURLs(imageURLs, maxImagesPerPost)
+	ctxLog.Info("Posting to Threads",
+		"image_count", len(imageURLs),
+		"chunk_count", len(chunks))
+
+	// Post the root chunk
 	postStart := time.Now()
+	rootPost, err := p.postChunk(ctx, chunks[0], postText, "")
+	if err != nil {
+		ctxLog.ErrorWithType("Failed to post root chunk to Threads", err,
+			"chunk_size", len(chunks[0]),
+			"upload_duration_ms", uploadDuration.Milliseconds(),
+			"total_duration_ms", time.Since(start).Milliseconds())
+		return err
+	}
+	ctxLog.Info("Root post published", "post_id", rootPost.ID, "images", len(chunks[0]))
 
-	if len(imageURLs) == 1 {
-		// Single image post
-		ctxLog.Info("Posting single image to Threads")
-		postErr = p.postSingleImage(ctx, imageURLs[0], postText)
-	} else if len(imageURLs) >= 2 && len(imageURLs) <= 20 {
-		// Carousel post
-		ctxLog.Info("Posting carousel to Threads", "images", len(imageURLs))
-		postErr = p.postCarousel(ctx, imageURLs, postText)
-	} else {
-		ctxLog.Error("Invalid number of images", "count", len(imageURLs))
-		return fmt.Errorf("invalid number of images: %d. Must be between 1 and 20", len(imageURLs))
+	// Chain replies for the remaining chunks. chunk_index in logs is 1-based;
+	// the root post is chunk 1, the first reply is chunk 2, etc.
+	prevID := rootPost.ID
+	for i := 1; i < len(chunks); i++ {
+		replyPost, replyErr := p.postChunk(ctx, chunks[i], "", prevID)
+		if replyErr != nil {
+			// Loss-tolerant: log loudly, stop the chain, but do not fail the
+			// whole Post() call. Caller will mark the document as processed so
+			// we don't re-publish the root on the next cycle.
+			ctxLog.ErrorWithType("Failed to post reply chunk; remaining images dropped", replyErr,
+				"root_post_id", rootPost.ID,
+				"chunk_index", i+1,
+				"total_chunks", len(chunks),
+				"chunk_size", len(chunks[i]),
+				"dropped_chunks", len(chunks)-i)
+			break
+		}
+		ctxLog.Info("Reply chunk published",
+			"post_id", replyPost.ID,
+			"reply_to", prevID,
+			"chunk_index", i+1,
+			"total_chunks", len(chunks),
+			"images", len(chunks[i]))
+		prevID = replyPost.ID
 	}
 
-	postDuration := time.Since(postStart)
 	totalDuration := time.Since(start)
-
-	if postErr != nil {
-		ctxLog.ErrorWithType("Failed to post to Threads", postErr,
-			"post_duration_ms", postDuration.Milliseconds(),
-			"total_duration_ms", totalDuration.Milliseconds())
-		return postErr
-	}
-
-	ctxLog.Info("Post to Threads completed successfully",
-		"post_duration_ms", postDuration.Milliseconds(),
+	ctxLog.Info("Post to Threads completed",
+		"chunks_total", len(chunks),
+		"posting_duration_ms", time.Since(postStart).Milliseconds(),
 		"upload_duration_ms", uploadDuration.Milliseconds(),
 		"total_duration_ms", totalDuration.Milliseconds())
 
@@ -188,63 +217,78 @@ func (p *Poster) uploadImages(ctx context.Context, images []image.Image) ([]stri
 	return imageURLs, nil
 }
 
-// postSingleImage posts a single image to Threads
-func (p *Poster) postSingleImage(ctx context.Context, imageURL, postText string) error {
+// postSingleImage posts a single image to Threads. If replyToID is non-empty,
+// the post is created as a reply to that post.
+func (p *Poster) postSingleImage(ctx context.Context, imageURL, postText, replyToID string) (*threads.Post, error) {
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "postSingleImage")
 
-	ctxLog.Debug("Creating single image post", "url", imageURL)
+	ctxLog.Debug("Creating single image post", "url", imageURL, "reply_to", replyToID)
 
-	// Use the threads-go client to create image post
-	_, err := p.ThreadsClient.CreateImagePost(ctx, &threads.ImagePostContent{
+	post, err := p.ThreadsClient.CreateImagePost(ctx, &threads.ImagePostContent{
 		Text:     postText,
 		ImageURL: imageURL,
+		ReplyTo:  replyToID,
 		TopicTag: TopicTag,
 	})
 	if err != nil {
 		ctxLog.Error("Failed to create image post", "error", err)
-		return fmt.Errorf("failed to create image post: %v", err)
+		return nil, fmt.Errorf("failed to create image post: %v", err)
 	}
 
-	ctxLog.Debug("Successfully posted single image")
-	return nil
+	ctxLog.Debug("Successfully posted single image", "post_id", post.ID)
+	return post, nil
 }
 
-// postCarousel posts multiple images as a carousel to Threads
-func (p *Poster) postCarousel(ctx context.Context, imageURLs []string, postText string) error {
+// postCarousel posts multiple images as a carousel to Threads. If replyToID
+// is non-empty, the carousel is posted as a reply to that post.
+func (p *Poster) postCarousel(ctx context.Context, imageURLs []string, postText, replyToID string) (*threads.Post, error) {
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "postCarousel").
 		WithContext("imageCount", len(imageURLs))
 
 	var containerIDs []string
 
-	// Create media containers for each image in the carousel
 	for i, imageURL := range imageURLs {
 		ctxLog.Debug("Creating media container for carousel image", "index", i+1)
 		containerID, err := p.ThreadsClient.CreateMediaContainer(ctx, threads.MediaTypeImage, imageURL, "")
 		if err != nil {
 			ctxLog.Error("Failed to create media container", "index", i+1, "error", err)
-			return fmt.Errorf("failed to create media container: %v", err)
+			return nil, fmt.Errorf("failed to create media container: %v", err)
 		}
-
-		containerIDStr := string(containerID)
-		containerIDs = append(containerIDs, containerIDStr)
+		containerIDs = append(containerIDs, string(containerID))
 	}
 
-	// Create carousel post
-	ctxLog.Debug("Creating carousel post", "itemCount", len(containerIDs))
-	_, err := p.ThreadsClient.CreateCarouselPost(ctx, &threads.CarouselPostContent{
+	ctxLog.Debug("Creating carousel post", "itemCount", len(containerIDs), "reply_to", replyToID)
+	post, err := p.ThreadsClient.CreateCarouselPost(ctx, &threads.CarouselPostContent{
 		Text:     postText,
 		Children: containerIDs,
+		ReplyTo:  replyToID,
 		TopicTag: TopicTag,
 	})
 	if err != nil {
 		ctxLog.Error("Failed to create carousel post", "error", err)
-		return fmt.Errorf("failed to create carousel post: %v", err)
+		return nil, fmt.Errorf("failed to create carousel post: %v", err)
 	}
 
-	ctxLog.Debug("Successfully posted carousel")
-	return nil
+	ctxLog.Debug("Successfully posted carousel", "post_id", post.ID)
+	return post, nil
+}
+
+// postChunk posts a single chunk of 1..maxImagesPerPost image URLs and returns
+// the resulting post. text is attached to the post (use "" for image-only
+// replies). replyToID, when non-empty, makes this a reply to that post.
+func (p *Poster) postChunk(ctx context.Context, imageURLs []string, text, replyToID string) (*threads.Post, error) {
+	switch n := len(imageURLs); {
+	case n == 1:
+		return p.postSingleImage(ctx, imageURLs[0], text, replyToID)
+	case n >= 2 && n <= maxImagesPerPost:
+		return p.postCarousel(ctx, imageURLs, text, replyToID)
+	default:
+		// Unreachable from Post (chunkURLs guarantees 1..maxImagesPerPost);
+		// retained as defense for any future direct caller.
+		return nil, fmt.Errorf("invalid chunk size: %d (must be 1..%d)", n, maxImagesPerPost)
+	}
 }
 
 // formatPostText formats the text for a post

--- a/bot/pkg/poster/poster.go
+++ b/bot/pkg/poster/poster.go
@@ -306,3 +306,20 @@ func truncateText(text string, limit int) string {
 
 	return text[:lastSpace] + ellipsis
 }
+
+// chunkURLs partitions urls into consecutive slices of length ≤ size.
+// Returns nil for an empty input. The last chunk may be shorter than size.
+func chunkURLs(urls []string, size int) [][]string {
+	if len(urls) == 0 {
+		return nil
+	}
+	chunks := make([][]string, 0, (len(urls)+size-1)/size)
+	for i := 0; i < len(urls); i += size {
+		end := i + size
+		if end > len(urls) {
+			end = len(urls)
+		}
+		chunks = append(chunks, urls[i:end])
+	}
+	return chunks
+}

--- a/bot/pkg/poster/poster.go
+++ b/bot/pkg/poster/poster.go
@@ -11,16 +11,18 @@ import (
 	"bot/pkg/utils"
 
 	"github.com/tirthpatell/threads-go"
+	"golang.org/x/sync/errgroup"
 )
 
 // Package logger
 var log = logger.Package("poster")
 
 const (
-	maxCharacterLimit = 500
-	maxImagesPerPost  = 20
-	ellipsis          = "..."
-	TopicTag          = "F1Threads"
+	maxCharacterLimit    = 500
+	maxImagesPerPost     = 20
+	maxConcurrentUploads = 5
+	ellipsis             = "..."
+	TopicTag             = "F1Threads"
 )
 
 // Poster is a struct that holds the configuration for the poster
@@ -189,28 +191,34 @@ func (p *Poster) PostTextOnly(ctx context.Context, text string) error {
 	return nil
 }
 
-// uploadImages uploads images to Picsur and returns their URLs
+// uploadImages uploads images to Picsur in parallel (bounded by
+// maxConcurrentUploads) and returns their URLs in the original order. The
+// first upload error cancels the remaining uploads via the errgroup context.
 func (p *Poster) uploadImages(ctx context.Context, images []image.Image) ([]string, error) {
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "uploadImages").
 		WithContext("imageCount", len(images))
 
-	var imageURLs []string
+	imageURLs := make([]string, len(images))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentUploads)
 
 	for i, img := range images {
-		// Add a small delay between uploads to prevent overwhelming the service
-		if i > 0 {
-			time.Sleep(500 * time.Millisecond)
-		}
+		g.Go(func() error {
+			ctxLog.Debug("Uploading image", "index", i+1)
+			url, err := p.PicsurClient.UploadImage(gctx, img)
+			if err != nil {
+				ctxLog.Error("Failed to upload image", "index", i+1, "error", err)
+				return fmt.Errorf("failed to upload image %d: %v", i+1, err)
+			}
+			imageURLs[i] = url
+			ctxLog.Debug("Uploaded image", "index", i+1, "total", len(images))
+			return nil
+		})
+	}
 
-		ctxLog.Debug("Uploading image", "index", i+1)
-		imageURL, err := p.PicsurClient.UploadImage(ctx, img)
-		if err != nil {
-			ctxLog.Error("Failed to upload image", "index", i+1, "error", err)
-			return nil, fmt.Errorf("failed to upload image %d: %v", i+1, err)
-		}
-		imageURLs = append(imageURLs, imageURL)
-		ctxLog.Debug("Uploaded image", "index", i+1, "total", len(images))
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	ctxLog.Info("All images uploaded successfully", "count", len(imageURLs))

--- a/bot/pkg/poster/poster_test.go
+++ b/bot/pkg/poster/poster_test.go
@@ -20,6 +20,12 @@ func TestChunkURLs(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "non-positive size returns nil",
+			urls: []string{"a", "b", "c"},
+			size: 0,
+			want: nil,
+		},
+		{
 			name: "single",
 			urls: []string{"a"},
 			size: 20,

--- a/bot/pkg/poster/poster_test.go
+++ b/bot/pkg/poster/poster_test.go
@@ -1,0 +1,73 @@
+package poster
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestChunkURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		urls []string
+		size int
+		want [][]string
+	}{
+		{
+			name: "empty",
+			urls: []string{},
+			size: 20,
+			want: nil,
+		},
+		{
+			name: "single",
+			urls: []string{"a"},
+			size: 20,
+			want: [][]string{{"a"}},
+		},
+		{
+			name: "exactly one chunk",
+			urls: makeURLs(20),
+			size: 20,
+			want: [][]string{makeURLs(20)},
+		},
+		{
+			name: "one over chunk size",
+			urls: makeURLs(21),
+			size: 20,
+			want: [][]string{makeURLs(20), {"url20"}},
+		},
+		{
+			name: "exactly two chunks",
+			urls: makeURLs(40),
+			size: 20,
+			want: [][]string{makeURLs(20), makeURLsFrom(20, 40)},
+		},
+		{
+			name: "two and a half chunks",
+			urls: makeURLs(45),
+			size: 20,
+			want: [][]string{makeURLs(20), makeURLsFrom(20, 40), makeURLsFrom(40, 45)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := chunkURLs(tt.urls, tt.size)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("chunkURLs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func makeURLs(n int) []string {
+	return makeURLsFrom(0, n)
+}
+
+func makeURLsFrom(start, end int) []string {
+	out := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		out = append(out, "url"+strconv.Itoa(i))
+	}
+	return out
+}

--- a/bot/pkg/utils/utils.go
+++ b/bot/pkg/utils/utils.go
@@ -92,7 +92,7 @@ func (c *Client) UploadImage(ctx context.Context, img image.Image) (string, erro
 	// Create request
 	uploadURL := fmt.Sprintf("%s/api/image/upload", c.BaseURL)
 	ctxLog.Debug("Creating upload request", "url", uploadURL)
-	req, err := http.NewRequest("POST", uploadURL, body)
+	req, err := http.NewRequestWithContext(ctx, "POST", uploadURL, body)
 	if err != nil {
 		ctxLog.Error("Failed to create request", "error", err)
 		return "", fmt.Errorf("failed to create request: %v", err)


### PR DESCRIPTION
## Summary

- **Fix:** Threads enforces 20 media items per post, so the bot was silently dropping any image past the 20th. Now partition uploads into chunks of 20 and chain remaining chunks as image-only replies, each parented to the previous post in the chain. The root post still carries the AI summary; replies are image-only.
- **Perf:** Picsur image uploads were sequential with a 500ms inter-upload sleep (~30s of mandatory sleep for a 60-image doc). Now uploads run concurrently bounded to 5 in-flight via `errgroup`, order preserved by indexed writes into a pre-sized slice. Also fixed `utils.UploadImage` to use `http.NewRequestWithContext` so the errgroup's first-failure cancellation actually reaches in-flight HTTP calls.
- **Tests:** Added the first test file in the bot module (`bot/pkg/poster/poster_test.go`) covering off-by-one boundaries of the new `chunkURLs` partition helper.

## Failure policy

- Root post fails → return error → caller skips marking the document processed → retry on next scrape cycle.
- Reply chunk fails → log loudly with `root_post_id`, `chunk_index`, `total_chunks`, `chunk_size`, `dropped_chunks`, `break` the chain, return `nil` → caller marks document processed. Trade-off accepted: tail images may be lost, but the root post is never duplicated on retry.

Closes #47. Fixes GRA-30.