### PR TITLE
fix: bump threads-go to v1.9.1 for /debug_token dev-mode fix

### DIFF
--- a/bot/go.mod
+++ b/bot/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.0
 	github.com/spf13/viper v1.21.0
-	github.com/tirthpatell/threads-go v1.7.1
+	github.com/tirthpatell/threads-go v1.9.1
 	golang.org/x/sync v0.20.0
 )
 

--- a/bot/go.sum
+++ b/bot/go.sum
@@ -103,8 +103,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
-github.com/tirthpatell/threads-go v1.7.1 h1:SVhYX0N5id6aFDFSoKv452BdbjboLq1gg9bQUmSO/rE=
-github.com/tirthpatell/threads-go v1.7.1/go.mod h1:TwJ1VhLWeQDDKkfiJ1OpH7ypI6TjYwUdF+x7aNtspGI=
+github.com/tirthpatell/threads-go v1.9.1 h1:bWyUqtbsbdxli8vqJP5kCvkDOJ2/34gwBMGRjwfr11A=
+github.com/tirthpatell/threads-go v1.9.1/go.mod h1:TwJ1VhLWeQDDKkfiJ1OpH7ypI6TjYwUdF+x7aNtspGI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=


### PR DESCRIPTION
## Summary

- Bumps `github.com/tirthpatell/threads-go` from v1.7.1 → v1.9.1.
- v1.9.1 ships [tirthpatell/threads-go#28](https://github.com/tirthpatell/threads-go/pull/28): `DebugToken` now sends `TH|<APP_ID>|<APP_SECRET>` as the caller on `/debug_token`. v1.7.1 sent the user access token, which Meta rejects on **Development-mode apps** with error code 100 (\"The app associated with this request is in dev mode\") — even when the user has a valid Threads Tester role.
- Symptom this fixes: poster init failing at startup with `failed to validate token: ... Failed to debug token` without any local config change, after Meta tightened dev-mode enforcement on that endpoint.