### PR TITLE
fix: bump threads-go to v1.9.2

### DIFF
--- a/bot/go.mod
+++ b/bot/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.0
 	github.com/spf13/viper v1.21.0
-	github.com/tirthpatell/threads-go v1.9.1
+	github.com/tirthpatell/threads-go v1.9.2
 	golang.org/x/sync v0.20.0
 )
 

--- a/bot/go.sum
+++ b/bot/go.sum
@@ -103,8 +103,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
-github.com/tirthpatell/threads-go v1.9.1 h1:bWyUqtbsbdxli8vqJP5kCvkDOJ2/34gwBMGRjwfr11A=
-github.com/tirthpatell/threads-go v1.9.1/go.mod h1:TwJ1VhLWeQDDKkfiJ1OpH7ypI6TjYwUdF+x7aNtspGI=
+github.com/tirthpatell/threads-go v1.9.2 h1:QRsP5LjARNZ+TikNdI9gYpJ99m/kg3w0HevMv8DG6hg=
+github.com/tirthpatell/threads-go v1.9.2/go.mod h1:TwJ1VhLWeQDDKkfiJ1OpH7ypI6TjYwUdF+x7aNtspGI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=


### PR DESCRIPTION
## Summary

- Bumps `github.com/tirthpatell/threads-go` v1.9.1 → v1.9.2.
- v1.9.2 ships [tirthpatell/threads-go#29](https://github.com/tirthpatell/threads-go/pull/29): `NewClientWithToken` falls back to `GET /v1.0/me` when `debug_token` returns HTTP 500 (which `graph.threads.net` does for valid tokens on dev-mode apps). Auth error codes 190/102 are now classified as non-retryable, eliminating the ~7s startup delay from retries before the fallback ran.
- Removes the temporary `cmd/test-poster` debug harness added during investigation.