### PR TITLE
fix: bump threads-go to v1.9.3 for /threads_publish recovery

### DIFF
--- a/bot/go.mod
+++ b/bot/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.0
 	github.com/spf13/viper v1.21.0
-	github.com/tirthpatell/threads-go v1.9.2
+	github.com/tirthpatell/threads-go v1.9.3
 	golang.org/x/sync v0.20.0
 )
 

--- a/bot/go.sum
+++ b/bot/go.sum
@@ -103,8 +103,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
-github.com/tirthpatell/threads-go v1.9.2 h1:QRsP5LjARNZ+TikNdI9gYpJ99m/kg3w0HevMv8DG6hg=
-github.com/tirthpatell/threads-go v1.9.2/go.mod h1:TwJ1VhLWeQDDKkfiJ1OpH7ypI6TjYwUdF+x7aNtspGI=
+github.com/tirthpatell/threads-go v1.9.3 h1:pogQ3+coeyjfM8SQY2m0x0BpLON/7TZOg4HAWpaTd0I=
+github.com/tirthpatell/threads-go v1.9.3/go.mod h1:TwJ1VhLWeQDDKkfiJ1OpH7ypI6TjYwUdF+x7aNtspGI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=


### PR DESCRIPTION
## Summary

Bumps `github.com/tirthpatell/threads-go` from `v1.9.2` to `v1.9.3`.

The fix in `tirthpatell/threads-go#30` resolves a production loop on this bot: when Meta's `/threads_publish` returns HTTP 5xx + error code 10 ("Application does not have permission for this action") **despite the container actually being PUBLISHED**, threads-go now:

- treats code 10 as non-retryable (one publish attempt instead of four, saves quota), and
- on that failure, gates on `GET /{container_id}?fields=status == PUBLISHED` and recovers the published post via `GET /me/threads?since=publishStart` using a content-specific matcher (carousels match by exact child-container-ID set; other types match by text/topic_tag/reply parent + quote state).

Before this bump: every carousel publish reported a false failure → `poster.Post()` returned `err` → `main.go` skipped the DB write → next scrape cycle re-published the same doc → loop, burning the daily publishing quota.