### PR TITLE
Efficiency and robustness improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The bot is configured using environment variables, loaded from a `.env` file via
 | `THREADS_CLIENT_SECRET` | Yes | | Threads OAuth client secret |
 | `THREADS_REDIRECT_URI` | Yes | | Threads OAuth redirect URI |
 | `GEMINI_API_KEY` | Yes | | Google Gemini API key |
-| `GEMINI_MODELS` | No | `gemini-3.1-flash-lite-preview:thinking,gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite` | Comma-separated Gemini models in fallback order; append `:thinking` to enable thinking for a model |
+| `GEMINI_MODELS` | No | `gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite` | Comma-separated Gemini models in fallback order; append `:thinking` to enable thinking for a model |
 | `PICSUR_API` | Yes | | Picsur API key |
 | `PICSUR_URL` | Yes | | Picsur instance URL |
 | `SHORTENER_API_KEY` | Yes | | URL shortener API key |

--- a/README.md
+++ b/README.md
@@ -185,12 +185,14 @@ The bot is configured using environment variables, loaded from a `.env` file via
 |---|---|---|---|
 | `FIA_URL` | No | 2025 season URL | FIA documents page URL |
 | `SCRAPE_INTERVAL` | No | `30` | Scraping interval in seconds |
+| `DOCUMENTS_TO_FETCH` | No | `15` | Number of recent documents to check each cycle |
 | `THREADS_ACCESS_TOKEN` | Yes | | Threads API access token |
 | `THREADS_USER_ID` | Yes | | Threads user ID |
 | `THREADS_CLIENT_ID` | Yes | | Threads OAuth client ID |
 | `THREADS_CLIENT_SECRET` | Yes | | Threads OAuth client secret |
 | `THREADS_REDIRECT_URI` | Yes | | Threads OAuth redirect URI |
 | `GEMINI_API_KEY` | Yes | | Google Gemini API key |
+| `GEMINI_MODELS` | No | `gemini-3.1-flash-lite-preview:thinking,gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite` | Comma-separated Gemini models in fallback order; append `:thinking` to enable thinking for a model |
 | `PICSUR_API` | Yes | | Picsur API key |
 | `PICSUR_URL` | Yes | | Picsur instance URL |
 | `SHORTENER_API_KEY` | Yes | | URL shortener API key |

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,11 +1,14 @@
 FIA_URL="BASE_URL_OF_FIA_DOCUMENTS" # https://www.fia.com/documents/championships/fia-formula-one-world-championship-14/season/season-2026-2072
 SCRAPE_INTERVAL="SCRAPING_INTERVAL_IN_SECONDS" # 30
+DOCUMENTS_TO_FETCH=15 # Number of recent documents to check each cycle
 THREADS_ACCESS_TOKEN="YOUR_THREADS_ACCESS_TOKEN"
 THREADS_USER_ID="YOUR_THREADS_USER_ID"
 THREADS_CLIENT_ID="THREADS_CLIENT_ID"
 THREADS_CLIENT_SECRET="THREADS_CLIENT_SECRET"
 THREADS_REDIRECT_URI="THREADS_REDIRECT_URI"
 GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
+# Comma-separated Gemini models in fallback order; append ":thinking" to enable thinking for a model
+GEMINI_MODELS="gemini-3.1-flash-lite-preview:thinking,gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite"
 PICSUR_API="YOUR_PICSUR_API_KEY"
 PICSUR_URL=https://picsur.example.com
 SHORTENER_API_KEY="YOUR_SHORTENER_API_KEY"

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -8,7 +8,7 @@ THREADS_CLIENT_SECRET="THREADS_CLIENT_SECRET"
 THREADS_REDIRECT_URI="THREADS_REDIRECT_URI"
 GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
 # Comma-separated Gemini models in fallback order; append ":thinking" to enable thinking for a model
-GEMINI_MODELS="gemini-3.1-flash-lite-preview:thinking,gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite"
+GEMINI_MODELS="gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite"
 PICSUR_API="YOUR_PICSUR_API_KEY"
 PICSUR_URL=https://picsur.example.com
 SHORTENER_API_KEY="YOUR_SHORTENER_API_KEY"

--- a/bot/cmd/svc/main.go
+++ b/bot/cmd/svc/main.go
@@ -41,7 +41,7 @@ func waitForDBConnection(ctx context.Context, store storage.StorageInterface) bo
 	// Get context-aware logger
 	dbLog := log.WithRequestContext(ctx).WithContext("component", "database")
 
-	err := store.CheckConnection()
+	err := store.CheckConnection(ctx)
 	if err == nil {
 		return true
 	}
@@ -58,7 +58,7 @@ func waitForDBConnection(ctx context.Context, store storage.StorageInterface) bo
 			return false
 		}
 
-		if err := store.CheckConnection(); err != nil {
+		if err := store.CheckConnection(ctx); err != nil {
 			dbLog.Error("Database still unreachable", "error", err)
 			interval = longRetryInterval
 		} else {
@@ -198,7 +198,7 @@ func main() {
 		healthLog := log.WithContext("component", "health_check")
 
 		// Check database connection
-		dbHealthy := store.CheckConnection() == nil
+		dbHealthy := store.CheckConnection(r.Context()) == nil
 
 		uptime := time.Since(startTime)
 		goroutines := runtime.NumGoroutine()
@@ -346,14 +346,16 @@ func main() {
 			var wg sync.WaitGroup
 			semaphore := make(chan struct{}, maxConcurrentProcessing)
 
-			// Create a map to track processed documents and then pass it to log
-			processedDocs := make(map[string]bool)
+			// Track skipped documents for a single summary log line. A slice
+			// (not a title-keyed map) so same-title documents with different
+			// URLs are each counted.
+			var skippedDocs []string
 
 			for _, doc := range docs {
 				// Skip already processed documents (checked before the recall
 				// handling so it covers recalled documents too)
 				if alreadyProcessed[storage.DocKey(doc.Title, doc.URL)] {
-					processedDocs[doc.Title] = true
+					skippedDocs = append(skippedDocs, doc.Title)
 					continue
 				}
 
@@ -381,8 +383,8 @@ func main() {
 						cycleLog.Error("Error updating storage", "error", err)
 					}
 
-					// Add to the processed docs map to avoid multiple notices
-					processedDocs[doc.Title] = true
+					// Include in the skipped-documents summary log
+					skippedDocs = append(skippedDocs, doc.Title)
 
 					continue
 				}
@@ -408,8 +410,8 @@ func main() {
 			}
 
 			// Log skipped documents after the loop (if any)
-			if len(processedDocs) > 0 {
-				cycleLog.Info("Skipping already processed document(s)", "Documents", processedDocs)
+			if len(skippedDocs) > 0 {
+				cycleLog.Info("Skipping already processed document(s)", "count", len(skippedDocs), "documents", skippedDocs)
 			}
 
 			// Wait for all goroutines to finish

--- a/bot/cmd/svc/main.go
+++ b/bot/cmd/svc/main.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	maxConcurrentProcessing = 5               // Maximum number of documents to process concurrently
-	documentsToFetch        = 15              // Number of recent documents to check
 	tempDir                 = "temp"          // Temporary directory for downloaded PDFs
 	shortRetryInterval      = 1 * time.Minute // Short retry interval for DB connection
 	longRetryInterval       = 5 * time.Minute // Long retry interval for DB connection
@@ -34,49 +33,50 @@ const (
 // Global logger
 var log *logger.Logger
 
-// waitForDBConnection attempts to establish a database connection with retries.
+// waitForDBConnection waits until the database is reachable, retrying with a
+// short interval first and a long interval after that. sql.DB is a
+// self-healing pool, so a successful ping is all that is needed to recover.
 // Returns false if the context was cancelled (shutdown requested).
 func waitForDBConnection(ctx context.Context, store storage.StorageInterface) bool {
 	// Get context-aware logger
 	dbLog := log.WithRequestContext(ctx).WithContext("component", "database")
 
-	// First try with short interval
-	if err := store.CheckConnection(); err != nil {
-		dbLog.Error("Database connection lost", "error", err)
-		dbLog.Info("Waiting before retrying", "interval", shortRetryInterval)
+	err := store.CheckConnection()
+	if err == nil {
+		return true
+	}
+
+	dbLog.Error("Database connection lost", "error", err)
+
+	interval := shortRetryInterval
+	for {
+		dbLog.Info("Waiting before retrying", "interval", interval)
 
 		select {
-		case <-time.After(shortRetryInterval):
+		case <-time.After(interval):
 		case <-ctx.Done():
 			return false
 		}
 
-		// Try to reconnect
-		if err := store.Reconnect(); err != nil {
-			dbLog.Error("Failed to reconnect to database", "error", err)
-
-			// Keep trying with long interval until successful or context cancelled
-			for {
-				dbLog.Info("Waiting before retrying", "interval", longRetryInterval)
-
-				select {
-				case <-time.After(longRetryInterval):
-				case <-ctx.Done():
-					return false
-				}
-
-				if err := store.Reconnect(); err != nil {
-					dbLog.Error("Failed to reconnect to database", "error", err)
-				} else {
-					dbLog.Info("Successfully reconnected to database")
-					break
-				}
-			}
+		if err := store.CheckConnection(); err != nil {
+			dbLog.Error("Database still unreachable", "error", err)
+			interval = longRetryInterval
 		} else {
-			dbLog.Info("Successfully reconnected to database")
+			dbLog.Info("Database connection re-established")
+			return true
 		}
 	}
-	return true
+}
+
+// sleepOrShutdown sleeps for the given duration. Returns false if the context
+// was cancelled (shutdown requested) before the duration elapsed.
+func sleepOrShutdown(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-time.After(d):
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func main() {
@@ -160,9 +160,11 @@ func main() {
 	appLog.Info("Initializing summarizer")
 	summarizer, err := summary.New(summary.Config{
 		APIKey: cfg.GeminiAPIKey,
+		Models: cfg.GeminiModels,
 	})
 	if err != nil {
 		appLog.Error("Failed to initialize summarizer", "error", err)
+		os.Exit(1)
 	}
 	defer summarizer.Close()
 
@@ -283,9 +285,11 @@ func main() {
 		}()
 
 		for {
+			// bgCtx is cancelled by main() on shutdown. Watching it here
+			// (rather than shutdownChan, whose single signal is consumed by
+			// main's blocking receive) is what lets this loop actually exit.
 			select {
-			case <-shutdownChan:
-				// Shutdown signal received, exit the loop
+			case <-bgCtx.Done():
 				return
 			default:
 				// Continue with normal processing
@@ -304,40 +308,51 @@ func main() {
 				return
 			}
 
-			docs, err := sc.FetchLatestDocuments(cycleCtx, documentsToFetch)
+			docs, err := sc.FetchLatestDocuments(cycleCtx, cfg.DocumentsToFetch)
 			if err != nil {
 				cycleLog.Error("Error fetching documents", "error", err)
 				cycleLog.Info("Sleeping before retrying", "seconds", cfg.ScrapeInterval)
-				time.Sleep(time.Duration(cfg.ScrapeInterval) * time.Second)
+				if !sleepOrShutdown(bgCtx, time.Duration(cfg.ScrapeInterval)*time.Second) {
+					return
+				}
 				continue
 			}
 
 			if len(docs) == 0 {
 				cycleLog.Info("No documents found for the current Grand Prix")
 				cycleLog.Info("Sleeping before retrying", "seconds", cfg.ScrapeInterval)
-				time.Sleep(time.Duration(cfg.ScrapeInterval) * time.Second)
+				if !sleepOrShutdown(bgCtx, time.Duration(cfg.ScrapeInterval)*time.Second) {
+					return
+				}
 				continue
 			}
 
 			cycleLog.Info("Documents fetched", "count", len(docs))
 
+			// Check which documents are already processed in a single query.
+			// On error, skip the cycle rather than assume "not processed" —
+			// proceeding on a failed check could re-post documents.
+			alreadyProcessed, err := store.FilterProcessed(cycleCtx, docs)
+			if err != nil {
+				cycleLog.Error("Error checking processed documents", "error", err)
+				cycleLog.Info("Sleeping before retrying", "seconds", cfg.ScrapeInterval)
+				if !sleepOrShutdown(bgCtx, time.Duration(cfg.ScrapeInterval)*time.Second) {
+					return
+				}
+				continue
+			}
+
 			// Create a worker pool with limited concurrency
 			var wg sync.WaitGroup
-			var workerCount int
 			semaphore := make(chan struct{}, maxConcurrentProcessing)
 
 			// Create a map to track processed documents and then pass it to log
 			processedDocs := make(map[string]bool)
 
 			for _, doc := range docs {
-				// Check database connection before checking if document is processed
-				if !waitForDBConnection(bgCtx, store) {
-					wg.Wait()
-					return
-				}
-
-				// Skip already processed documents (moved this check earlier to handle all docs including recalled ones)
-				if store.IsDocumentProcessed(cycleCtx, doc) {
+				// Skip already processed documents (checked before the recall
+				// handling so it covers recalled documents too)
+				if alreadyProcessed[storage.DocKey(doc.Title, doc.URL)] {
 					processedDocs[doc.Title] = true
 					continue
 				}
@@ -375,7 +390,6 @@ func main() {
 				// Limit concurrency using semaphore
 				semaphore <- struct{}{}
 				wg.Add(1)
-				workerCount++
 
 				go func(document *scraper.Document) {
 					defer wg.Done()
@@ -401,16 +415,10 @@ func main() {
 			// Wait for all goroutines to finish
 			wg.Wait()
 
-			// GC once per cycle after all workers complete. Running it here
-			// (rather than in each worker) avoids N back-to-back STW pauses
-			// when multiple workers finish concurrently. Skip when no workers
-			// were spawned (all docs already processed).
-			if workerCount > 0 {
-				runtime.GC()
-			}
-
 			cycleLog.Info("Sleeping before next check", "seconds", cfg.ScrapeInterval)
-			time.Sleep(time.Duration(cfg.ScrapeInterval) * time.Second)
+			if !sleepOrShutdown(bgCtx, time.Duration(cfg.ScrapeInterval)*time.Second) {
+				return
+			}
 		}
 	}()
 
@@ -539,16 +547,6 @@ func processDocument(ctx context.Context, doc *scraper.Document, scraper *scrape
 	}
 
 	docLog.Info("Successfully posted to Threads")
-
-	// Drop image references before potentially blocking on DB reconnect.
-	// Each page is a Go-managed []byte (go-fitz copies pixel data out of C
-	// memory inside Image() and frees the C pixmap before returning), so
-	// nil-ing here lets the GC reclaim the large buffers while this goroutine
-	// may be blocked waiting for a DB reconnect.
-	for i := range images {
-		images[i] = nil
-	}
-	images = nil
 
 	// Check database connection before updating
 	if !waitForDBConnection(ctx, store) {

--- a/bot/pkg/config/config.go
+++ b/bot/pkg/config/config.go
@@ -54,7 +54,7 @@ func Load() (*Config, error) {
 	viper.SetDefault("DOCUMENTS_TO_FETCH", 15)
 	// Comma-separated Gemini models in order of preference; a ":thinking"
 	// suffix enables thinking for that model.
-	viper.SetDefault("GEMINI_MODELS", "gemini-3.1-flash-lite-preview:thinking,gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite")
+	viper.SetDefault("GEMINI_MODELS", "gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite")
 	viper.SetDefault("DB_PORT", "5432")
 	viper.SetDefault("DB_SSL_MODE", "disable")
 	viper.SetDefault("LOG_LEVEL", "info")

--- a/bot/pkg/config/config.go
+++ b/bot/pkg/config/config.go
@@ -24,7 +24,9 @@ type Config struct {
 	ThreadsClientSecret string `mapstructure:"THREADS_CLIENT_SECRET"`
 	ThreadsRedirectURI  string `mapstructure:"THREADS_REDIRECT_URI"`
 	ScrapeInterval      int    `mapstructure:"SCRAPE_INTERVAL"`
+	DocumentsToFetch    int    `mapstructure:"DOCUMENTS_TO_FETCH"`
 	GeminiAPIKey        string `mapstructure:"GEMINI_API_KEY"`
+	GeminiModels        string `mapstructure:"GEMINI_MODELS"`
 	PicsurAPI           string `mapstructure:"PICSUR_API"`
 	PicsurURL           string `mapstructure:"PICSUR_URL"`
 	ShortenerAPIKey     string `mapstructure:"SHORTENER_API_KEY"`
@@ -49,6 +51,10 @@ func Load() (*Config, error) {
 
 	// Set default values before unmarshalling so they take effect
 	viper.SetDefault("SCRAPE_INTERVAL", 30)
+	viper.SetDefault("DOCUMENTS_TO_FETCH", 15)
+	// Comma-separated Gemini models in order of preference; a ":thinking"
+	// suffix enables thinking for that model.
+	viper.SetDefault("GEMINI_MODELS", "gemini-3.1-flash-lite-preview:thinking,gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite")
 	viper.SetDefault("DB_PORT", "5432")
 	viper.SetDefault("DB_SSL_MODE", "disable")
 	viper.SetDefault("LOG_LEVEL", "info")
@@ -83,6 +89,9 @@ func Load() (*Config, error) {
 	if cfg.GeminiAPIKey == "" {
 		return nil, fmt.Errorf("GEMINI_API_KEY is required")
 	}
+	if cfg.GeminiModels == "" {
+		return nil, fmt.Errorf("GEMINI_MODELS is required")
+	}
 	if cfg.PicsurURL == "" {
 		return nil, fmt.Errorf("PICSUR_URL is required")
 	}
@@ -91,6 +100,10 @@ func Load() (*Config, error) {
 	}
 	if cfg.ShortenerURL == "" {
 		return nil, fmt.Errorf("SHORTENER_URL is required")
+	}
+
+	if cfg.DocumentsToFetch <= 0 {
+		return nil, fmt.Errorf("DOCUMENTS_TO_FETCH must be positive, got %d", cfg.DocumentsToFetch)
 	}
 
 	// Validate PostgreSQL configuration

--- a/bot/pkg/poster/poster.go
+++ b/bot/pkg/poster/poster.go
@@ -326,20 +326,21 @@ func (p *Poster) formatPostText(ctx context.Context, title string, publishTime t
 			title, publishTime.Format("02-01-2006 15:04 MST"))
 	}
 
-	// Only attach the summary section when there is a summary; a failed
-	// generation should not leave a dangling "AI Summary:" label.
-	if aiSummary == "" {
-		return baseText, nil
+	// Only attach the summary section when there is a summary (a failed
+	// generation should not leave a dangling "AI Summary:" label) and there
+	// is room for it — the final truncation below would otherwise cut the
+	// text mid-label.
+	const summaryLabel = "\n\nAI Summary: "
+	remainingChars := maxCharacterLimit - utf8.RuneCountInString(baseText) - utf8.RuneCountInString(summaryLabel)
+
+	text := baseText
+	if aiSummary != "" && remainingChars > 0 {
+		text += summaryLabel + truncateText(aiSummary, remainingChars)
 	}
 
-	const summaryLabel = "\n\nAI Summary: "
-	remainingChars := maxCharacterLimit - utf8.RuneCountInString(baseText) - len(summaryLabel)
-
-	// Truncate AI summary if needed
-	truncatedSummary := truncateText(aiSummary, remainingChars)
-
-	// Combine all parts
-	return baseText + summaryLabel + truncatedSummary, nil
+	// Final guard: an unusually long title can push baseText itself past the
+	// limit, so truncate the assembled text as a whole.
+	return truncateText(text, maxCharacterLimit), nil
 }
 
 // truncateText truncates text to the specified limit (counted in runes, since

--- a/bot/pkg/poster/poster.go
+++ b/bot/pkg/poster/poster.go
@@ -3,9 +3,9 @@ package poster
 import (
 	"context"
 	"fmt"
-	"image"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"bot/pkg/logger"
 	"bot/pkg/utils"
@@ -30,7 +30,6 @@ type Poster struct {
 	ThreadsClient   *threads.Client
 	PicsurClient    *utils.Client
 	ShortenerClient *utils.ShortenerClient
-	AccessToken     string
 }
 
 // New creates a new Poster
@@ -54,7 +53,6 @@ func New(accessToken, userID, clientID, clientSecret, redirectURI, picsurAPI, pi
 		ThreadsClient:   threadsClient,
 		PicsurClient:    utils.New(picsurAPI, picsurURL),
 		ShortenerClient: utils.NewShortenerClient(shortenerAPIKey, shortenerURL),
-		AccessToken:     accessToken,
 	}, nil
 }
 
@@ -70,7 +68,7 @@ func New(accessToken, userID, clientID, clientSecret, redirectURI, picsurAPI, pi
 //     index, then returns nil. The root post and any earlier replies remain
 //     published; the document is marked processed so we don't re-publish the
 //     root on the next cycle. Some tail images may be lost.
-func (p *Poster) Post(ctx context.Context, images []image.Image, title string, publishTime time.Time, documentURL, aiSummary string) error {
+func (p *Poster) Post(ctx context.Context, images [][]byte, title string, publishTime time.Time, documentURL, aiSummary string) error {
 	start := time.Now()
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "Post")
@@ -103,7 +101,7 @@ func (p *Poster) Post(ctx context.Context, images []image.Image, title string, p
 		ctxLog.ErrorWithType("Failed to format post text", err)
 		return err
 	}
-	ctxLog.Debug("Post character count", "chars", len(postText))
+	ctxLog.Debug("Post character count", "chars", utf8.RuneCountInString(postText))
 
 	// Partition images into chunks of ≤ maxImagesPerPost
 	chunks := chunkURLs(imageURLs, maxImagesPerPost)
@@ -166,8 +164,8 @@ func (p *Poster) PostTextOnly(ctx context.Context, text string) error {
 		WithContext("method", "PostTextOnly")
 
 	// Truncate text if it exceeds the character limit
-	if len(text) > maxCharacterLimit {
-		ctxLog.Warn("Truncating text due to character limit", "original", len(text), "limit", maxCharacterLimit)
+	if utf8.RuneCountInString(text) > maxCharacterLimit {
+		ctxLog.Warn("Truncating text due to character limit", "original", utf8.RuneCountInString(text), "limit", maxCharacterLimit)
 		text = truncateText(text, maxCharacterLimit)
 	}
 
@@ -191,10 +189,10 @@ func (p *Poster) PostTextOnly(ctx context.Context, text string) error {
 	return nil
 }
 
-// uploadImages uploads images to Picsur in parallel (bounded by
+// uploadImages uploads PNG-encoded images to Picsur in parallel (bounded by
 // maxConcurrentUploads) and returns their URLs in the original order. The
 // first upload error cancels the remaining uploads via the errgroup context.
-func (p *Poster) uploadImages(ctx context.Context, images []image.Image) ([]string, error) {
+func (p *Poster) uploadImages(ctx context.Context, images [][]byte) ([]string, error) {
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "uploadImages").
 		WithContext("imageCount", len(images))
@@ -321,25 +319,34 @@ func (p *Poster) formatPostText(ctx context.Context, title string, publishTime t
 	// Create the base text with or without the shortened URL
 	var baseText string
 	if shortenedURL != "" {
-		baseText = fmt.Sprintf("New document: %s\nPublished on: %s\nLink: %s\n\nAI Summary: ",
+		baseText = fmt.Sprintf("New document: %s\nPublished on: %s\nLink: %s",
 			title, publishTime.Format("02-01-2006 15:04 MST"), shortenedURL)
 	} else {
-		baseText = fmt.Sprintf("New document: %s\nPublished on: %s\n\nAI Summary: ",
+		baseText = fmt.Sprintf("New document: %s\nPublished on: %s",
 			title, publishTime.Format("02-01-2006 15:04 MST"))
 	}
 
-	remainingChars := maxCharacterLimit - len(baseText)
+	// Only attach the summary section when there is a summary; a failed
+	// generation should not leave a dangling "AI Summary:" label.
+	if aiSummary == "" {
+		return baseText, nil
+	}
+
+	const summaryLabel = "\n\nAI Summary: "
+	remainingChars := maxCharacterLimit - utf8.RuneCountInString(baseText) - len(summaryLabel)
 
 	// Truncate AI summary if needed
 	truncatedSummary := truncateText(aiSummary, remainingChars)
 
 	// Combine all parts
-	return baseText + truncatedSummary, nil
+	return baseText + summaryLabel + truncatedSummary, nil
 }
 
-// truncateText truncates text to the specified limit, adding an ellipsis
+// truncateText truncates text to the specified limit (counted in runes, since
+// the Threads limit is characters, not bytes), adding an ellipsis.
 func truncateText(text string, limit int) string {
-	if len(text) <= limit {
+	runes := []rune(text)
+	if len(runes) <= limit {
 		return text
 	}
 
@@ -350,13 +357,14 @@ func truncateText(text string, limit int) string {
 	}
 
 	// Find the last space before the limit to avoid cutting words in the middle
-	lastSpace := strings.LastIndex(text[:limit], " ")
+	truncated := string(runes[:limit])
+	lastSpace := strings.LastIndex(truncated, " ")
 	if lastSpace == -1 {
 		// If no space found, just cut at the limit
-		return text[:limit] + ellipsis
+		return truncated + ellipsis
 	}
 
-	return text[:lastSpace] + ellipsis
+	return truncated[:lastSpace] + ellipsis
 }
 
 // topicTagForReply returns the topic tag to apply to a post: TopicTag for the
@@ -378,10 +386,7 @@ func chunkURLs(urls []string, size int) [][]string {
 	}
 	chunks := make([][]string, 0, (len(urls)+size-1)/size)
 	for i := 0; i < len(urls); i += size {
-		end := i + size
-		if end > len(urls) {
-			end = len(urls)
-		}
+		end := min(i+size, len(urls))
 		chunks = append(chunks, urls[i:end])
 	}
 	return chunks

--- a/bot/pkg/poster/truncate_test.go
+++ b/bot/pkg/poster/truncate_test.go
@@ -1,0 +1,36 @@
+package poster
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateText(t *testing.T) {
+	// Multi-byte input: must count runes and never split one.
+	text := strings.Repeat("é", 600)
+	got := truncateText(text, 500)
+	if !utf8.ValidString(got) {
+		t.Error("truncation split a rune")
+	}
+	if utf8.RuneCountInString(got) > 500 {
+		t.Errorf("got %d runes, want <= 500", utf8.RuneCountInString(got))
+	}
+	if !strings.HasSuffix(got, ellipsis) {
+		t.Error("missing ellipsis")
+	}
+
+	// Short text passes through untouched.
+	if got := truncateText("short", 500); got != "short" {
+		t.Errorf("short text changed: %q", got)
+	}
+
+	// Word-boundary truncation.
+	got = truncateText("hello world this is a long sentence", 15)
+	if utf8.RuneCountInString(got) > 15 {
+		t.Errorf("got %d runes, want <= 15", utf8.RuneCountInString(got))
+	}
+	if !strings.HasSuffix(got, ellipsis) {
+		t.Error("missing ellipsis")
+	}
+}

--- a/bot/pkg/poster/truncate_test.go
+++ b/bot/pkg/poster/truncate_test.go
@@ -1,8 +1,10 @@
 package poster
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 )
 
@@ -32,5 +34,38 @@ func TestTruncateText(t *testing.T) {
 	}
 	if !strings.HasSuffix(got, ellipsis) {
 		t.Error("missing ellipsis")
+	}
+}
+
+// formatPostText must never produce text over the Threads character limit,
+// even when a very long title leaves no room for the summary section.
+func TestFormatPostTextRespectsCharacterLimit(t *testing.T) {
+	p := &Poster{} // documentURL is empty in all cases, so no clients are used
+	publishTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		title   string
+		summary string
+	}{
+		{"normal", "Doc 12 - Car 44 - Alleged breach", "Steward summary text."},
+		{"empty summary", "Doc 12 - Car 44", ""},
+		{"long summary", "Doc 12", strings.Repeat("word ", 200)},
+		{"title fills the limit", strings.Repeat("x", 480), "Some summary."},
+		{"title leaves no room for label", strings.Repeat("x", 460), "Some summary."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := p.formatPostText(context.Background(), tt.title, publishTime, "", tt.summary)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if n := utf8.RuneCountInString(got); n > maxCharacterLimit {
+				t.Errorf("post text is %d runes, want <= %d", n, maxCharacterLimit)
+			}
+			if strings.HasSuffix(got, "AI Summary: ") {
+				t.Error("dangling AI Summary label")
+			}
+		})
 	}
 }

--- a/bot/pkg/scraper/scraper.go
+++ b/bot/pkg/scraper/scraper.go
@@ -50,6 +50,17 @@ func getRandomUserAgent() string {
 	return userAgents[rand.Intn(len(userAgents))]
 }
 
+// parisTZ is the timezone FIA publish dates are expressed in. Loaded once;
+// falls back to UTC if the tz database is unavailable.
+var parisTZ = func() *time.Location {
+	loc, err := time.LoadLocation("Europe/Paris")
+	if err != nil {
+		log.Error("Failed to load Europe/Paris timezone, falling back to UTC", "error", err)
+		return time.UTC
+	}
+	return loc
+}()
+
 // FetchLatestDocuments retrieves the specified number of most recent documents
 func (s *Scraper) FetchLatestDocuments(ctx context.Context, limit int) ([]*Document, error) {
 	// Get a context-aware logger
@@ -91,13 +102,6 @@ func (s *Scraper) FetchLatestDocuments(ctx context.Context, limit int) ([]*Docum
 
 					fullURL := "https://www.fia.com" + relativeURL
 
-					// Load the Europe/Paris timezone
-					parisTZ, err := time.LoadLocation("Europe/Paris")
-					if err != nil {
-						ctxLog.Error("Failed to load Europe/Paris timezone", "error", err)
-						parisTZ = time.UTC // Fallback to UTC if loading fails
-					}
-
 					// Parse the time assuming it's in the Paris timezone
 					published, err := time.ParseInLocation("02.01.06 15:04", publishedStr, parisTZ)
 					if err != nil {
@@ -117,7 +121,10 @@ func (s *Scraper) FetchLatestDocuments(ctx context.Context, limit int) ([]*Docum
 					documents = append(documents, doc)
 					ctxLog.Debug("Found document", "title", title, "publishedUTC", publishedUTC)
 				})
-				// Stop after processing the active Grand Prix
+				// Note: this return only ends the current ForEach callback
+				// iteration; it does not break the loop. Only one Grand Prix
+				// is marked active at a time, so the other iterations are
+				// no-ops anyway.
 				return
 			}
 		})

--- a/bot/pkg/storage/postgres.go
+++ b/bot/pkg/storage/postgres.go
@@ -145,6 +145,21 @@ func NewPostgres(host, port, user, password, dbname, sslmode string) (StorageInt
 		}
 	}
 
+	// Ensure the composite unique index exists regardless of how the schema
+	// was provisioned (fresh create, migrated, or manual): AddProcessedDocument's
+	// ON CONFLICT (title, url) fails at runtime without a matching unique
+	// index. Both the CREATE TABLE UNIQUE clause and the migration's ADD
+	// CONSTRAINT back their constraint with an index of this name, so this is
+	// a no-op on healthy schemas.
+	_, err = db.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS processed_documents_title_url_key
+		ON processed_documents (title, url)
+	`)
+	if err != nil {
+		ctxLog.Error("Error ensuring unique index on (title, url)", "error", err)
+		return nil, fmt.Errorf("error ensuring unique index on (title, url): %v", err)
+	}
+
 	ctxLog.Info("PostgreSQL storage initialized successfully")
 	return &PostgresStorage{
 		db: db,
@@ -152,10 +167,10 @@ func NewPostgres(host, port, user, password, dbname, sslmode string) (StorageInt
 }
 
 // CheckConnection checks if the database connection is still active
-func (s *PostgresStorage) CheckConnection() error {
-	ctxLog := log.WithContext("method", "CheckConnection")
+func (s *PostgresStorage) CheckConnection(ctx context.Context) error {
+	ctxLog := log.WithRequestContext(ctx).WithContext("method", "CheckConnection")
 
-	err := s.db.Ping()
+	err := s.db.PingContext(ctx)
 	if err != nil {
 		ctxLog.Error("Database connection check failed", "error", err)
 	} else {

--- a/bot/pkg/storage/postgres.go
+++ b/bot/pkg/storage/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"bot/pkg/logger"
@@ -15,10 +16,11 @@ import (
 // Package logger
 var log = logger.Package("storage")
 
-// PostgresStorage implements the StorageInterface using PostgreSQL
+// PostgresStorage implements the StorageInterface using PostgreSQL.
+// sql.DB is a self-healing connection pool: dropped connections are
+// re-established transparently, so there is no explicit reconnect logic.
 type PostgresStorage struct {
-	db      *sql.DB
-	connStr string
+	db *sql.DB
 }
 
 // NewPostgres creates a new PostgreSQL storage
@@ -145,44 +147,8 @@ func NewPostgres(host, port, user, password, dbname, sslmode string) (StorageInt
 
 	ctxLog.Info("PostgreSQL storage initialized successfully")
 	return &PostgresStorage{
-		db:      db,
-		connStr: connStr,
+		db: db,
 	}, nil
-}
-
-// Reconnect attempts to reconnect to the database
-func (s *PostgresStorage) Reconnect() error {
-	ctxLog := log.WithContext("method", "Reconnect")
-
-	// Close the existing connection if it exists
-	if s.db != nil {
-		ctxLog.Info("Closing existing database connection")
-		_ = s.db.Close() // Ignore close errors
-	}
-
-	// Create a new connection
-	ctxLog.Info("Creating new database connection")
-	db, err := sql.Open("postgres", s.connStr)
-	if err != nil {
-		ctxLog.Error("Error reconnecting to database", "error", err)
-		return fmt.Errorf("error reconnecting to database: %v", err)
-	}
-
-	// Re-apply connection pool settings
-	db.SetMaxOpenConns(10)
-	db.SetMaxIdleConns(5)
-	db.SetConnMaxLifetime(5 * time.Minute)
-
-	// Test the connection
-	if err := db.Ping(); err != nil {
-		ctxLog.Error("Error pinging database after reconnect", "error", err)
-		return fmt.Errorf("error pinging database after reconnect: %v", err)
-	}
-
-	// Update the db reference
-	s.db = db
-	ctxLog.Info("Successfully reconnected to database")
-	return nil
 }
 
 // CheckConnection checks if the database connection is still active
@@ -206,89 +172,89 @@ func (s *PostgresStorage) Close() error {
 	return s.db.Close()
 }
 
-// AddProcessedDocument adds a document to the processed documents list
+// AddProcessedDocument adds a document to the processed documents list.
+// The insert is atomic: the UNIQUE(title, url) constraint plus ON CONFLICT
+// DO NOTHING makes re-adding an already processed document a no-op.
 func (s *PostgresStorage) AddProcessedDocument(ctx context.Context, doc ProcessedDocument) error {
 	start := time.Now()
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "AddProcessedDocument").
 		WithContext("url", doc.URL)
 
-	// Check if the document already exists
-	var exists bool
-	ctxLog.Debug("Checking if document already exists")
-	checkStart := time.Now()
-	err := s.db.QueryRow("SELECT EXISTS(SELECT 1 FROM processed_documents WHERE url = $1 AND title = $2)",
-		doc.URL, doc.Title).Scan(&exists)
-	checkDuration := time.Since(checkStart)
-
-	if err != nil {
-		ctxLog.ErrorWithType("Error checking if document exists", err,
-			"query_duration_ms", checkDuration.Milliseconds())
-		return fmt.Errorf("error checking if document exists: %v", err)
-	}
-
-	ctxLog.Debug("Document existence check completed",
-		"exists", exists,
-		"query_duration_ms", checkDuration.Milliseconds())
-
-	if exists {
-		ctxLog.Info("Document already processed, skipping",
-			"total_duration_ms", time.Since(start).Milliseconds())
-		return nil // Already processed
-	}
-
-	// Insert the document
 	ctxLog.Info(fmt.Sprintf("Adding document to processed list: %s", doc.Title))
-	insertStart := time.Now()
-	_, err = s.db.Exec(
-		"INSERT INTO processed_documents (title, url, timestamp) VALUES ($1, $2, $3)",
+	res, err := s.db.ExecContext(ctx,
+		"INSERT INTO processed_documents (title, url, timestamp) VALUES ($1, $2, $3) ON CONFLICT (title, url) DO NOTHING",
 		doc.Title, doc.URL, doc.Timestamp,
 	)
-	insertDuration := time.Since(insertStart)
-	totalDuration := time.Since(start)
+	duration := time.Since(start)
 
 	if err != nil {
 		ctxLog.ErrorWithType("Error inserting document", err,
-			"insert_duration_ms", insertDuration.Milliseconds(),
-			"total_duration_ms", totalDuration.Milliseconds())
+			"insert_duration_ms", duration.Milliseconds())
 		return fmt.Errorf("error inserting document: %v", err)
 	}
 
+	if rows, raErr := res.RowsAffected(); raErr == nil && rows == 0 {
+		ctxLog.Info("Document already processed, skipping",
+			"insert_duration_ms", duration.Milliseconds())
+		return nil
+	}
+
 	ctxLog.Info("Document added to processed list successfully",
-		"insert_duration_ms", insertDuration.Milliseconds(),
-		"total_duration_ms", totalDuration.Milliseconds())
+		"insert_duration_ms", duration.Milliseconds())
 
 	return nil
 }
 
-// IsDocumentProcessed checks if a document has been processed
-func (s *PostgresStorage) IsDocumentProcessed(ctx context.Context, doc *scraper.Document) bool {
+// FilterProcessed returns the set of already-processed documents among docs
+// in a single query, keyed by DocKey(title, url).
+func (s *PostgresStorage) FilterProcessed(ctx context.Context, docs []*scraper.Document) (map[string]bool, error) {
 	start := time.Now()
 	ctxLog := log.WithRequestContext(ctx).
-		WithContext("method", "IsDocumentProcessed")
+		WithContext("method", "FilterProcessed")
 
-	var exists bool
-	err := s.db.QueryRow("SELECT EXISTS(SELECT 1 FROM processed_documents WHERE url = $1 AND title = $2)",
-		doc.URL, doc.Title).Scan(&exists)
-	duration := time.Since(start)
+	processed := make(map[string]bool, len(docs))
+	if len(docs) == 0 {
+		return processed, nil
+	}
 
+	placeholders := make([]string, 0, len(docs))
+	args := make([]any, 0, len(docs)*2)
+	for i, doc := range docs {
+		placeholders = append(placeholders, fmt.Sprintf("($%d, $%d)", i*2+1, i*2+2))
+		args = append(args, doc.Title, doc.URL)
+	}
+
+	query := "SELECT title, url FROM processed_documents WHERE (title, url) IN (" +
+		strings.Join(placeholders, ", ") + ")"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		// If there's a database error, we'll assume it's not processed
-		// The main loop will handle reconnection
-		ctxLog.ErrorWithType("Error checking if document exists", err,
-			"query_duration_ms", duration.Milliseconds())
-		return false
+		ctxLog.ErrorWithType("Error querying processed documents", err,
+			"query_duration_ms", time.Since(start).Milliseconds())
+		return nil, fmt.Errorf("error querying processed documents: %v", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			ctxLog.Warn("Error closing rows", "error", err)
+		}
+	}()
+
+	for rows.Next() {
+		var title, url string
+		if err := rows.Scan(&title, &url); err != nil {
+			return nil, fmt.Errorf("error scanning processed document: %v", err)
+		}
+		processed[DocKey(title, url)] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating processed documents: %v", err)
 	}
 
-	ctxLog.Debug("Document processed check completed",
-		"exists", exists,
-		"query_duration_ms", duration.Milliseconds())
+	ctxLog.Debug("Processed documents check completed",
+		"checked", len(docs),
+		"already_processed", len(processed),
+		"query_duration_ms", time.Since(start).Milliseconds())
 
-	if exists {
-		ctxLog.Debug("Document is already processed")
-	} else {
-		ctxLog.Debug("Document is not processed yet")
-	}
-
-	return exists
+	return processed, nil
 }

--- a/bot/pkg/storage/storage.go
+++ b/bot/pkg/storage/storage.go
@@ -23,7 +23,7 @@ type StorageInterface interface {
 	FilterProcessed(ctx context.Context, docs []*scraper.Document) (map[string]bool, error)
 
 	// CheckConnection checks if the database connection is still active
-	CheckConnection() error
+	CheckConnection(ctx context.Context) error
 
 	// Close closes the storage (if needed)
 	Close() error

--- a/bot/pkg/storage/storage.go
+++ b/bot/pkg/storage/storage.go
@@ -18,15 +18,18 @@ type StorageInterface interface {
 	// AddProcessedDocument adds a document to the processed documents list
 	AddProcessedDocument(ctx context.Context, doc ProcessedDocument) error
 
-	// IsDocumentProcessed checks if a document has been processed
-	IsDocumentProcessed(ctx context.Context, doc *scraper.Document) bool
+	// FilterProcessed returns the set of already-processed documents among
+	// docs, keyed by DocKey. Documents absent from the map are unprocessed.
+	FilterProcessed(ctx context.Context, docs []*scraper.Document) (map[string]bool, error)
 
 	// CheckConnection checks if the database connection is still active
 	CheckConnection() error
 
-	// Reconnect attempts to reconnect to the database if the connection is lost
-	Reconnect() error
-
 	// Close closes the storage (if needed)
 	Close() error
+}
+
+// DocKey builds the lookup key used by FilterProcessed results.
+func DocKey(title, url string) string {
+	return title + "\x00" + url
 }

--- a/bot/pkg/summary/summary.go
+++ b/bot/pkg/summary/summary.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"bot/pkg/logger"
@@ -16,10 +17,15 @@ var log = logger.Package("summary")
 
 type Summarizer struct {
 	client *genai.Client
+	models []modelEntry
 }
 
 type Config struct {
 	APIKey string
+	// Models is a comma-separated list of Gemini model names in order of
+	// preference. A ":thinking" suffix enables thinking for that model,
+	// e.g. "gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite".
+	Models string
 }
 
 type modelEntry struct {
@@ -27,19 +33,39 @@ type modelEntry struct {
 	useThinking bool
 }
 
-// Models in order of preference
-var modelPriority = []modelEntry{
-	{name: "gemini-3.1-flash-lite-preview", useThinking: true},
-	{name: "gemini-3.1-flash-lite", useThinking: true},
-	{name: "gemini-2.5-flash-lite"},
-	{name: "gemini-2.0-flash-lite"},
-	{name: "gemini-2.0-flash"},
-	{name: "gemini-1.5-flash-8b"},
+// parseModels parses a comma-separated model list (see Config.Models).
+func parseModels(s string) ([]modelEntry, error) {
+	var models []modelEntry
+	for entry := range strings.SplitSeq(s, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		name, suffix, found := strings.Cut(entry, ":")
+		model := modelEntry{name: name}
+		if found {
+			if suffix != "thinking" {
+				return nil, fmt.Errorf("invalid model entry %q: unknown suffix %q (only \":thinking\" is supported)", entry, suffix)
+			}
+			model.useThinking = true
+		}
+		models = append(models, model)
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("model list is empty")
+	}
+	return models, nil
 }
 
 // New creates a new instance of Summarizer
 func New(cfg Config) (*Summarizer, error) {
 	ctxLog := log.WithContext("method", "New")
+
+	models, err := parseModels(cfg.Models)
+	if err != nil {
+		ctxLog.Error("Invalid Gemini model list", "models", cfg.Models, "error", err)
+		return nil, fmt.Errorf("invalid Gemini model list %q: %w", cfg.Models, err)
+	}
 
 	ctx := context.Background()
 	ctxLog.Info("Creating Vertex AI client")
@@ -52,9 +78,10 @@ func New(cfg Config) (*Summarizer, error) {
 		return nil, fmt.Errorf("error creating Vertex AI client: %w", err)
 	}
 
-	ctxLog.Info("Summarizer initialized successfully")
+	ctxLog.Info("Summarizer initialized successfully", "models", cfg.Models)
 	return &Summarizer{
 		client: client,
+		models: models,
 	}, nil
 }
 
@@ -81,7 +108,7 @@ func (s *Summarizer) GenerateSummary(ctx context.Context, pdfPath string) (strin
 
 	// Try each model in order of priority
 	var lastError error
-	for _, model := range modelPriority {
+	for _, model := range s.models {
 		ctxLog.Debug("Attempting to generate summary", "model", model.name)
 		summary, err := s.tryGenerateSummaryWithModel(ctx, model, pdfData)
 		if err == nil {

--- a/bot/pkg/summary/summary_test.go
+++ b/bot/pkg/summary/summary_test.go
@@ -1,0 +1,26 @@
+package summary
+
+import "testing"
+
+func TestParseModels(t *testing.T) {
+	models, err := parseModels("gemini-3.1-flash-lite-preview:thinking, gemini-3.1-flash-lite:thinking,gemini-2.5-flash-lite")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 3 {
+		t.Fatalf("want 3 models, got %d: %+v", len(models), models)
+	}
+	if !models[0].useThinking || models[0].name != "gemini-3.1-flash-lite-preview" {
+		t.Errorf("bad first entry: %+v", models[0])
+	}
+	if models[2].useThinking || models[2].name != "gemini-2.5-flash-lite" {
+		t.Errorf("bad last entry: %+v", models[2])
+	}
+
+	if _, err := parseModels(""); err == nil {
+		t.Error("empty list should error")
+	}
+	if _, err := parseModels("model:bogus"); err == nil {
+		t.Error("unknown suffix should error")
+	}
+}

--- a/bot/pkg/utils/utils.go
+++ b/bot/pkg/utils/utils.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"image"
-	"image/png"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -50,7 +48,9 @@ func New(apiKey, baseURL string) *Client {
 	}
 }
 
-func (c *Client) UploadImage(ctx context.Context, img image.Image) (string, error) {
+// UploadImage uploads an already PNG-encoded image to Picsur and returns its
+// public URL.
+func (c *Client) UploadImage(ctx context.Context, pngData []byte) (string, error) {
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "UploadImage")
 
@@ -58,14 +58,6 @@ func (c *Client) UploadImage(ctx context.Context, img image.Image) (string, erro
 	if c.BaseURL == "" {
 		ctxLog.Error("Picsur base URL not configured")
 		return "", fmt.Errorf("picsur base URL not configured")
-	}
-
-	// Encode image to PNG
-	var buf bytes.Buffer
-	ctxLog.Debug("Encoding image to PNG")
-	if err := png.Encode(&buf, img); err != nil {
-		ctxLog.Error("Failed to encode image", "error", err)
-		return "", fmt.Errorf("failed to encode image: %v", err)
 	}
 
 	// Prepare multipart form data
@@ -79,7 +71,7 @@ func (c *Client) UploadImage(ctx context.Context, img image.Image) (string, erro
 		ctxLog.Error("Failed to create form file", "error", err)
 		return "", fmt.Errorf("failed to create form file: %v", err)
 	}
-	if _, err := io.Copy(part, &buf); err != nil {
+	if _, err := part.Write(pngData); err != nil {
 		ctxLog.Error("Failed to copy image data", "error", err)
 		return "", fmt.Errorf("failed to copy image data: %v", err)
 	}
@@ -139,8 +131,13 @@ func EncodeURL(input string) string {
 	return strings.ReplaceAll(input, " ", "%20")
 }
 
-// ConvertToImages converts a PDF document to a slice of images
-func ConvertToImages(ctx context.Context, pdfPath string) ([]image.Image, error) {
+// renderDPI matches go-fitz's Image() default so output quality is unchanged.
+const renderDPI = 300
+
+// ConvertToImages converts a PDF document to a slice of PNG-encoded pages.
+// Encoding happens page by page so only one raw decoded page is held in
+// memory at a time.
+func ConvertToImages(ctx context.Context, pdfPath string) ([][]byte, error) {
 	ctxLog := log.WithRequestContext(ctx).
 		WithContext("method", "ConvertToImages").
 		WithContext("pdfPath", pdfPath)
@@ -161,11 +158,11 @@ func ConvertToImages(ctx context.Context, pdfPath string) ([]image.Image, error)
 	numPages := doc.NumPage()
 	ctxLog.Debug("Converting PDF to images", "pages", numPages)
 
-	var images []image.Image
+	images := make([][]byte, 0, numPages)
 
 	for i := range numPages {
 		ctxLog.Debug("Converting page to image", "page", i+1)
-		img, err := doc.Image(i)
+		img, err := doc.ImagePNG(i, renderDPI)
 		if err != nil {
 			ctxLog.Error("Failed to convert page to image", "page", i+1, "error", err)
 			return nil, fmt.Errorf("failed to convert page %d to image: %v", i, err)


### PR DESCRIPTION
## Summary

- **New env vars**: `DOCUMENTS_TO_FETCH` (default 15) and `GEMINI_MODELS` (comma-separated fallback list, `:thinking` suffix enables thinking per model) — no more rebuilds to tune fetch count or swap models. Retired Gemini fallback models pruned from the default list.
- **Graceful shutdown fixed**: the processing loop now watches the shared cancel context instead of racing `main()` for the single OS signal, and all cycle sleeps are interruptible. Previously every shutdown hit the 30s force-exit path.
- **Memory**: PDF pages are encoded straight to PNG bytes one page at a time (same 300 DPI, identical output), removing the need to hold all raw decoded pages through upload; the per-cycle `runtime.GC()` workaround and manual image nil-ing are gone, as is a redundant buffer copy in the Picsur upload.
- **Database**: `AddProcessedDocument` is a single atomic `INSERT ... ON CONFLICT DO NOTHING`; the duplicate check is one batched query per cycle instead of a ping + query per document; the racy `Reconnect` (unsynchronized `sql.DB` swap under concurrent workers) is removed — the pool self-heals, so ping-with-retry suffices. A failed duplicate check now skips the cycle instead of assuming "not processed", closing a re-posting hole.
- **Post formatting**: no dangling "AI Summary:" label when generation fails; character limit counted in runes (not bytes) so accented characters can't overflow or get split; final guard keeps assembled text ≤ 500 chars even with extreme titles (caught by review + regression test).
- Smaller: Paris timezone loaded once instead of per document; exit on summarizer init failure instead of deferring `Close()` on nil; unused `Poster.AccessToken` removed; misleading scraper comment fixed.

Defaults mirror current behavior — existing `.env` needs no changes. Docker/image changes deliberately excluded.

Tests added for model-list parsing, rune-aware truncation, and the character-limit edge cases; `go build`, `go vet`, and all tests pass.